### PR TITLE
blk_interposer patch v5 for kernel 5.11.11 and  5.10.27

### DIFF
--- a/blk_interposer/patch-v5_for_v5.11.11/0001-block-add-blk_mq_is_queue_frozen.patch
+++ b/blk_interposer/patch-v5_for_v5.11.11/0001-block-add-blk_mq_is_queue_frozen.patch
@@ -1,0 +1,52 @@
+From 513d65743fa77667e30545d5e73e177b6841cc12 Mon Sep 17 00:00:00 2001
+From: Sergei Shtepa <sergei.shtepa@veeam.com>
+Date: Tue, 9 Feb 2021 12:57:49 +0100
+Subject: [PATCH 1/2] block: add blk_mq_is_queue_frozen()
+
+blk_mq_is_queue_frozen() allow to assert that the queue is frozen.
+
+Signed-off-by: Sergei Shtepa <sergei.shtepa@veeam.com>
+---
+ block/blk-mq.c         | 13 +++++++++++++
+ include/linux/blk-mq.h |  1 +
+ 2 files changed, 14 insertions(+)
+
+diff --git a/block/blk-mq.c b/block/blk-mq.c
+index 2a1eff60c797..9e467892b76b 100644
+--- a/block/blk-mq.c
++++ b/block/blk-mq.c
+@@ -159,6 +159,19 @@ int blk_mq_freeze_queue_wait_timeout(struct request_queue *q,
+ }
+ EXPORT_SYMBOL_GPL(blk_mq_freeze_queue_wait_timeout);
+ 
++
++bool blk_mq_is_queue_frozen(struct request_queue *q)
++{
++	bool ret;
++
++	mutex_lock(&q->mq_freeze_lock);
++	ret = percpu_ref_is_dying(&q->q_usage_counter) && percpu_ref_is_zero(&q->q_usage_counter);
++	mutex_unlock(&q->mq_freeze_lock);
++
++	return ret;
++}
++EXPORT_SYMBOL_GPL(blk_mq_is_queue_frozen);
++
+ /*
+  * Guarantee no request is in use, so we can change any data structure of
+  * the queue afterward.
+diff --git a/include/linux/blk-mq.h b/include/linux/blk-mq.h
+index f8ea27423d1d..17f2128a4fd7 100644
+--- a/include/linux/blk-mq.h
++++ b/include/linux/blk-mq.h
+@@ -524,6 +524,7 @@ void blk_freeze_queue_start(struct request_queue *q);
+ void blk_mq_freeze_queue_wait(struct request_queue *q);
+ int blk_mq_freeze_queue_wait_timeout(struct request_queue *q,
+ 				     unsigned long timeout);
++bool blk_mq_is_queue_frozen(struct request_queue *q);
+ 
+ int blk_mq_map_queues(struct blk_mq_queue_map *qmap);
+ void blk_mq_update_nr_hw_queues(struct blk_mq_tag_set *set, int nr_hw_queues);
+-- 
+2.20.1
+

--- a/blk_interposer/patch-v5_for_v5.11.11/0002-block-add-blk_interposer.patch
+++ b/blk_interposer/patch-v5_for_v5.11.11/0002-block-add-blk_interposer.patch
@@ -1,0 +1,260 @@
+From e380dc6483ea01aa87ad0a26e699b06b159af115 Mon Sep 17 00:00:00 2001
+From: Sergei Shtepa <sergei.shtepa@veeam.com>
+Date: Mon, 3 May 2021 12:53:49 +0200
+Subject: [PATCH 2/2] block: add blk_interposer
+
+blk_interposer allows to intercept bio requests, remap bio
+to another devices or add new bios.
+
+Signed-off-by: Sergei Shtepa <sergei.shtepa@veeam.com>
+---
+ block/bio.c               |  2 +
+ block/blk-core.c          | 35 ++++++++++++++++
+ block/genhd.c             | 87 +++++++++++++++++++++++++++++++++++++++
+ include/linux/blk_types.h |  6 ++-
+ include/linux/genhd.h     | 18 ++++++++
+ 5 files changed, 146 insertions(+), 2 deletions(-)
+
+diff --git a/block/bio.c b/block/bio.c
+index 9c931df2d986..ec8ce1d17ac1 100644
+--- a/block/bio.c
++++ b/block/bio.c
+@@ -684,6 +684,8 @@ void __bio_clone_fast(struct bio *bio, struct bio *bio_src)
+ 	bio_set_flag(bio, BIO_CLONED);
+ 	if (bio_flagged(bio_src, BIO_THROTTLED))
+ 		bio_set_flag(bio, BIO_THROTTLED);
++	if (bio_flagged(bio_src, BIO_INTERPOSED))
++		bio_set_flag(bio, BIO_INTERPOSED);
+ 	bio->bi_opf = bio_src->bi_opf;
+ 	bio->bi_ioprio = bio_src->bi_ioprio;
+ 	bio->bi_write_hint = bio_src->bi_write_hint;
+diff --git a/block/blk-core.c b/block/blk-core.c
+index 2d53e2ff48ff..ea9f1cf71e0d 100644
+--- a/block/blk-core.c
++++ b/block/blk-core.c
+@@ -1031,6 +1031,34 @@ static blk_qc_t __submit_bio_noacct_mq(struct bio *bio)
+ 	return ret;
+ }
+ 
++static blk_qc_t __submit_bio_interposed(struct bio *bio)
++{
++	struct bio_list bio_list[2] = { };
++	blk_qc_t ret = BLK_QC_T_NONE;
++
++	current->bio_list = bio_list;
++	if (likely(bio_queue_enter(bio) == 0)) {
++		struct gendisk *disk = bio->bi_disk;
++
++		if (likely(blk_has_interposer(disk))) {
++			bio_set_flag(bio, BIO_INTERPOSED);
++			disk->interposer->ip_submit_bio(bio);
++		} else {
++			/* interposer was removed */
++			bio_list_add(&current->bio_list[0], bio);
++		}
++
++		blk_queue_exit(disk->queue);
++	}
++	current->bio_list = NULL;
++
++	/* Resubmit remaining bios */
++	while ((bio = bio_list_pop(&bio_list[0])))
++		ret = submit_bio_noacct(bio);
++
++	return ret;
++}
++
+ /**
+  * submit_bio_noacct - re-submit a bio to the block device layer for I/O
+  * @bio:  The bio describing the location in memory and on the device.
+@@ -1056,6 +1084,13 @@ blk_qc_t submit_bio_noacct(struct bio *bio)
+ 		return BLK_QC_T_NONE;
+ 	}
+ 
++	/*
++	 * Checking the BIO_INTERPOSED flag is necessary so that the bio
++	 * created by the blk_interposer do not get to it for processing.
++	 */
++	if (blk_has_interposer(bio->bi_disk) &&
++	    !bio_flagged(bio, BIO_INTERPOSED))
++		return __submit_bio_interposed(bio);
+ 	if (!bio->bi_disk->fops->submit_bio)
+ 		return __submit_bio_noacct_mq(bio);
+ 	return __submit_bio_noacct(bio);
+diff --git a/block/genhd.c b/block/genhd.c
+index 796baf761202..159680b11a62 100644
+--- a/block/genhd.c
++++ b/block/genhd.c
+@@ -29,6 +29,12 @@
+ static DEFINE_MUTEX(block_class_lock);
+ static struct kobject *block_depr;
+ 
++/*
++ * Prevents different block-layer interposers from attaching or detaching
++ * to the disk at the same time.
++ */
++DEFINE_MUTEX(blk_interposer_attach_lock);
++
+ /* for extended dynamic devt allocation, currently only one major is used */
+ #define NR_EXT_DEVT		(1 << MINORBITS)
+ 
+@@ -2365,3 +2371,84 @@ static void disk_release_events(struct gendisk *disk)
+ 	WARN_ON_ONCE(disk->ev && disk->ev->block != 1);
+ 	kfree(disk->ev);
+ }
++
++/**
++ * blk_interposer_attach - Attach interposer to disk
++ * @disk: target disk
++ * @interposer: block device interposer
++ * @ip_submit_bio: hook for submit_bio()
++ *
++ * Returns:
++ *     -EINVAL if @interposer is NULL.
++ *     -EPERM if queue is not frozen.
++ *     -EBUSY if the block device already has @interposer.
++ *     -EALREADY if the block device already has @interposer with same callback.
++ *
++ * Disk must be frozen by blk_mq_freeze_queue().
++ */
++int blk_interposer_attach(struct gendisk *disk, struct blk_interposer *interposer,
++			  const ip_submit_bio_t ip_submit_bio)
++{
++	int ret = 0;
++
++	if (WARN_ON(!interposer))
++		return -EINVAL;
++
++	if (!blk_mq_is_queue_frozen(disk->queue))
++		return -EPERM;
++
++	mutex_lock(&blk_interposer_attach_lock);
++	if (blk_has_interposer(disk)) {
++		if (disk->interposer->ip_submit_bio == ip_submit_bio)
++			ret = -EALREADY;
++		else
++			ret = -EBUSY;
++		goto out;
++	}
++
++	interposer->ip_submit_bio = ip_submit_bio;
++	interposer->disk = disk;
++
++	disk->interposer = interposer;
++out:
++	mutex_unlock(&blk_interposer_attach_lock);
++
++	return ret;
++}
++EXPORT_SYMBOL_GPL(blk_interposer_attach);
++
++/**
++ * blk_interposer_detach - Detach interposer from disk
++ * @interposer: block device interposer
++ * @ip_submit_bio: hook for submit_bio()
++ *
++ * Disk must be frozen by blk_mq_freeze_queue().
++ */
++void blk_interposer_detach(struct blk_interposer *interposer,
++			  const ip_submit_bio_t ip_submit_bio)
++{
++	struct gendisk *disk;
++
++	if (WARN_ON(!interposer))
++		return;
++
++	mutex_lock(&blk_interposer_attach_lock);
++
++	/* Check if the interposer is still active. */
++	disk = interposer->disk;
++	if (WARN_ON(!disk))
++		goto out;
++
++	if (WARN_ON(!blk_mq_is_queue_frozen(disk->queue)))
++		goto out;
++
++	/* Check if it is really our interposer. */
++	if (WARN_ON(disk->interposer->ip_submit_bio != ip_submit_bio))
++		goto out;
++
++	disk->interposer = NULL;
++	interposer->disk = NULL;
++out:
++	mutex_unlock(&blk_interposer_attach_lock);
++}
++EXPORT_SYMBOL_GPL(blk_interposer_detach);
+diff --git a/include/linux/blk_types.h b/include/linux/blk_types.h
+index d9b69bbde5cc..996b803e5aa1 100644
+--- a/include/linux/blk_types.h
++++ b/include/linux/blk_types.h
+@@ -207,7 +207,7 @@ struct bio {
+ 						 * top bits REQ_OP. Use
+ 						 * accessors.
+ 						 */
+-	unsigned short		bi_flags;	/* status, etc and bvec pool number */
++	unsigned int		bi_flags;	/* status, etc and bvec pool number */
+ 	unsigned short		bi_ioprio;
+ 	unsigned short		bi_write_hint;
+ 	blk_status_t		bi_status;
+@@ -284,6 +284,8 @@ enum {
+ 				 * of this bio. */
+ 	BIO_CGROUP_ACCT,	/* has been accounted to a cgroup */
+ 	BIO_TRACKED,		/* set if bio goes through the rq_qos path */
++	BIO_INTERPOSED,		/* bio has been interposed and can be moved to
++				 * a different disk */
+ 	BIO_FLAG_LAST
+ };
+ 
+@@ -302,7 +304,7 @@ enum {
+  * freed.
+  */
+ #define BVEC_POOL_BITS		(3)
+-#define BVEC_POOL_OFFSET	(16 - BVEC_POOL_BITS)
++#define BVEC_POOL_OFFSET	(32 - BVEC_POOL_BITS)
+ #define BVEC_POOL_IDX(bio)	((bio)->bi_flags >> BVEC_POOL_OFFSET)
+ #if (1<< BVEC_POOL_BITS) < (BVEC_POOL_NR+1)
+ # error "BVEC_POOL_BITS is too small"
+diff --git a/include/linux/genhd.h b/include/linux/genhd.h
+index 03da3f603d30..8da5c0bda27c 100644
+--- a/include/linux/genhd.h
++++ b/include/linux/genhd.h
+@@ -164,6 +164,13 @@ struct blk_integrity {
+ 	unsigned char				tag_size;
+ };
+ 
++typedef void (*ip_submit_bio_t) (struct bio *bio);
++
++struct blk_interposer {
++	ip_submit_bio_t ip_submit_bio;
++	struct gendisk *disk;
++};
++
+ struct gendisk {
+ 	/* major, first_minor and minors are input parameters only,
+ 	 * don't use directly.  Use disk_devt() and disk_max_parts().
+@@ -188,6 +195,7 @@ struct gendisk {
+ 
+ 	const struct block_device_operations *fops;
+ 	struct request_queue *queue;
++	struct blk_interposer *interposer;
+ 	void *private_data;
+ 
+ 	int flags;
+@@ -409,4 +417,14 @@ static inline dev_t blk_lookup_devt(const char *name, int partno)
+ }
+ #endif /* CONFIG_BLOCK */
+ 
++/*
++ * block layer interposer
++ */
++#define blk_has_interposer(d) ((d)->interposer != NULL)
++
++int blk_interposer_attach(struct gendisk *disk, struct blk_interposer *interposer,
++			  const ip_submit_bio_t ip_submit_bio);
++void blk_interposer_detach(struct blk_interposer *interposer,
++			   const ip_submit_bio_t ip_submit_bio);
++
+ #endif /* _LINUX_GENHD_H */
+-- 
+2.20.1
+


### PR DESCRIPTION
March 30 at gendisk.c the linux-rolling-stable (5.11.11) and
linux-rolling-lts(5.10.27) branches have been changed, so the patch
has been updated.