### PR TITLE
Support for kernel 5.12

### DIFF
--- a/source/blk_direct.c
+++ b/source/blk_direct.c
@@ -124,8 +124,15 @@ int _dev_direct_submit_pages(
 #ifdef BIO_MAX_SECTORS
         size_sector = min_t( sector_t, size_sector, BIO_MAX_SECTORS );
 #else
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION( 5, 12, 0 )
+        size_sector = min_t( sector_t, size_sector, (BIO_MAX_VECS << (PAGE_SHIFT - SECTOR_SHIFT)) );
+#else
         size_sector = min_t( sector_t, size_sector, (BIO_MAX_PAGES << (PAGE_SHIFT - SECTOR_SHIFT)) );
 #endif
+
+#endif
+
 
     }
 

--- a/source/blk_redirect.c
+++ b/source/blk_redirect.c
@@ -164,7 +164,13 @@ int _blk_dev_redirect_part_fast( blk_redirect_bio_endio_t* rq_endio, int directi
 #ifdef BIO_MAX_SECTORS
         max_sect = BIO_MAX_SECTORS;
 #else
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION( 5, 12, 0 )
+        max_sect = BIO_MAX_VECS << (PAGE_SHIFT - SECTOR_SHIFT);
+#else
         max_sect = BIO_MAX_PAGES << (PAGE_SHIFT - SECTOR_SHIFT);
+#endif
+
 #endif
         max_sect = min( max_sect, q->limits.max_sectors );
     }

--- a/source/snapdata_collect.c
+++ b/source/snapdata_collect.c
@@ -323,7 +323,13 @@ int snapdata_collect_Find(struct bio *bio, struct request_queue *queue, snapdata
         snapdata_collector_t* collector = (snapdata_collector_t*)content;
         if (
 #if defined(VEEAMSNAP_DISK_SUBMIT_BIO)
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION( 5, 12, 0 )
+            (collector->device->bd_disk == bio->bi_bdev->bd_disk)
+#else  
             (collector->device->bd_disk == bio->bi_disk)
+#endif
+
 #else
             (collector->device->bd_disk->queue == queue)
 #endif

--- a/source/snapimage.c
+++ b/source/snapimage.c
@@ -645,7 +645,13 @@ blk_qc_t _snapimage_make_request(struct request_queue *q, struct bio *bio)
 #else
 blk_qc_t _snapimage_submit_bio(struct bio *bio)
 {
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION( 5, 12, 0 )
+    struct request_queue *q = bio->bi_bdev->bd_disk->queue;
+#else
     struct request_queue *q = bio->bi_disk->queue;
+#endif
+
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION( 4, 4, 0 )

--- a/source/tracking.c
+++ b/source/tracking.c
@@ -141,7 +141,13 @@ blk_qc_t tracking_make_request( struct request_queue *q, struct bio *bio )
     bio_get(bio);
 
 #if defined(VEEAMSNAP_DISK_SUBMIT_BIO)
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION( 5, 12, 0 )
+    if (SUCCESS == tracker_disk_find(bio->bi_bdev->bd_disk, &tr_disk))
+#else
     if (SUCCESS == tracker_disk_find(bio->bi_disk, &tr_disk))
+#endif
+
 #else
     if (SUCCESS == tracker_disk_find(q, &tr_disk))
 #endif


### PR DESCRIPTION
Enables support for kernel 5.12
- BIO_MAX_PAGES is renamed to BIO_MAX_VECS
- bio->bi_disk is renamed and moved to bio->bi_bdev->bd_disk