### PR TITLE
update to use _printk instead of printk

### DIFF
--- a/source/ctrl_fops.c
+++ b/source/ctrl_fops.c
@@ -347,7 +347,7 @@ int ioctl_set_kernel_entries(unsigned long arg)
     kfree(name);
     if (ret)
         goto out;
-    symbols_offset = (unsigned long)(printk) - (unsigned long)entries[0].addr;
+    symbols_offset = (unsigned long)(_printk) - (unsigned long)entries[0].addr;
 
     for (inx=1; inx<param.count; inx++) {
         name = strndup_user(entries[inx].name, KERNEL_ENTRY_NAME_MAX);


### PR DESCRIPTION
With kernel 5.15.2 make breaks with the following error:

/home/philipraets/Git/Github/veeamsnap/source/ctrl_fops.c: In function ‘ioctl_set_kernel_entries’:
/home/philipraets/Git/Github/veeamsnap/source/ctrl_fops.c:350:38: error: ‘printk’ undeclared (first use in this function); did you mean ‘_printk’?
  350 |     symbols_offset = (unsigned long)(printk) - (unsigned long)entries[0].addr;
      |                                      ^~~~~~
      |                                      _printk
/home/philipraets/Git/Github/veeamsnap/source/ctrl_fops.c:350:38: note: each undeclared identifier is reported only once for each function it appears in
make[2]: *** [/usr/src/linux-5.15.2-1/scripts/Makefile.build:278: /home/philipraets/Git/Github/veeamsnap/source/ctrl_fops.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [../../../linux-5.15.2-1/Makefile:1882: /home/philipraets/Git/Github/veeamsnap/source] Error 2
make[1]: Leaving directory '/usr/src/linux-5.15.2-1-obj/x86_64/default'
make: *** [Makefile:72: default] Error 2


switching printk to _printk fixes the error